### PR TITLE
vox_tabcomplete: use r-strings

### DIFF
--- a/xontrib/vox_tabcomplete.xsh
+++ b/xontrib/vox_tabcomplete.xsh
@@ -14,10 +14,10 @@ def _vox_completer(prefix, line, begidx, endidx, ctx):
     if (len(line.split()) > 1 and line.endswith(' ')) or len(line.split()) > 2:
         # "vox new " -> complete flags if any
         command = line.strip().split()[-1]
-        flags = set(re.findall('(--\w+)', $(vox @(command) --help)))
+        flags = set(re.findall(r'(--\w+)', $(vox @(command) --help)))
         return flags, len(prefix)
 
-    all_commands = re.findall('\n    (\w+)', $(vox --help))
+    all_commands = re.findall(r'\n    (\w+)', $(vox --help))
     if prefix in all_commands:
         # "vox new" -> suggest replacing new with other command (note no space)
         return all_commands, len(prefix)


### PR DESCRIPTION
Before this change, the strings had invalid escape codes so I'm not sure this could ever work correctly. Regardless, we should just use r''-style strings.